### PR TITLE
Add Python formatting, linting and type-checking hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,21 @@ repos:
         entry: scripts/precommit_hardcoded_rules.sh
         language: system
         stages: [commit]
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]

--- a/tests/precommit_sample.py
+++ b/tests/precommit_sample.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+def main() -> None:
+    print(os.path.basename(sys.argv[0]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- configure standard pre-commit hooks (black, isort, flake8, mypy)
- add sample script to verify hook execution

## Testing
- `pre-commit run --files tests/precommit_sample.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5e860d48322b27b50af8b3fbbbc