### PR TITLE
Add tests for topic manager and harvester endpoints

### DIFF
--- a/harvester/tests/test_trigger_harvest_mock.py
+++ b/harvester/tests/test_trigger_harvest_mock.py
@@ -1,0 +1,59 @@
+
+import importlib.util
+import sys
+import pathlib
+from typing import List, Dict, Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+BASE = pathlib.Path(__file__).resolve().parents[1] / 'src'
+
+def _load_module(name: str):
+    spec = importlib.util.spec_from_file_location(f'harvester_module.{name}', BASE / f'{name}.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+# Preload dependent modules for relative imports
+_load_module('config')
+models = _load_module('models')
+_load_module('fetcher')
+_load_module('storage')
+RawTrendItem = models.RawTrendItem
+
+main_spec = importlib.util.spec_from_file_location('harvester_module.main', BASE / 'main.py')
+harvester_main = importlib.util.module_from_spec(main_spec)
+harvester_main.__package__ = 'harvester_module'
+main_spec.loader.exec_module(harvester_main)  # type: ignore
+app = harvester_main.app
+
+
+class DummyFetcher:
+    async def run(self, limit: int = 5) -> Tuple[List[RawTrendItem], Dict[str, str]]:
+        item = RawTrendItem(title='t1', source='dummy', keywords=['k'])
+        return [item], {}
+
+
+class DummyStorage:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def save_items(self, items: List[RawTrendItem]) -> int:
+        return len(items)
+
+
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(harvester_main, 'FetcherEngine', lambda: DummyFetcher())
+    monkeypatch.setattr(harvester_main, 'StorageService', lambda *a, **k: DummyStorage())
+
+
+def test_trigger_harvest_mock() -> None:
+    client = TestClient(app)
+    resp = client.post('/harvest/trigger')
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['fetched'] == 1
+    assert body['saved'] == 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,8 @@ python_files = test_*.py
 # Full suite can be enabled with ENABLE_FULL_SUITE=1 (see root conftest.py)
 testpaths =
     kolegium/ai_writing_flow/tests
+    topic-manager/tests
+    harvester/tests
 
 markers =
     core: Core Phase 2 tests (safe by default)

--- a/topic-manager/tests/test_main_endpoints.py
+++ b/topic-manager/tests/test_main_endpoints.py
@@ -1,0 +1,40 @@
+import sys
+import pathlib
+from typing import Dict, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure src in path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+from main import app as fastapi_app  # type: ignore
+
+def _seed_topic(client: TestClient, title: str = "AI Test") -> None:
+    payload: Dict[str, Any] = {
+        "title": title,
+        "description": "Desc",
+        "keywords": ["ai"],
+        "content_type": "POST",
+    }
+    client.post("/topics/manual", json=payload)
+
+@pytest.fixture(autouse=True)
+def clear_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure tests do not require auth token."""
+    monkeypatch.delenv("TOPIC_MANAGER_TOKEN", raising=False)
+
+def test_list_topics_returns_items() -> None:
+    client = TestClient(fastapi_app)
+    _seed_topic(client, title="First topic")
+    resp = client.get("/topics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data and data["count"] >= 1
+
+def test_novelty_check_basic() -> None:
+    client = TestClient(fastapi_app)
+    _seed_topic(client, title="Novelty Seed")
+    resp = client.post("/topics/novelty-check", json={"title": "Novelty Seed"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(["decision", "similarity_score", "nearest", "threshold"]).issubset(body)


### PR DESCRIPTION
## Summary
- add basic tests for `/topics` listing and `/topics/novelty-check` endpoints
- test `/harvest/trigger` in mock mode with dummy fetcher and storage
- configure pytest to collect tests from topic-manager and harvester modules

## Testing
- `ENABLE_FULL_SUITE=1 pytest topic-manager/tests/test_main_endpoints.py harvester/tests/test_trigger_harvest_mock.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0e6026fd883228792403dca65d643