### PR TITLE
Refactor app state to dataclass

### DIFF
--- a/editorial-service/src/state.py
+++ b/editorial-service/src/state.py
@@ -1,0 +1,18 @@
+"""Application state dataclass for FastAPI service."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class AppState:
+    """Container for application wide state."""
+
+    redis_client: Optional[Any] = None
+    startup_time: Optional[float] = None
+    health_checks: Dict[str, Any] = field(default_factory=dict)
+    chromadb_client: Optional[Any] = None
+    health_response_cache: Optional[Dict[str, Any]] = None
+    health_cache_refresh_inflight: bool = False
+    checkpoints: Dict[str, Any] = field(default_factory=dict)
+

--- a/editorial-service/tests/unit/test_main.py
+++ b/editorial-service/tests/unit/test_main.py
@@ -166,7 +166,10 @@ class TestRedisIntegration:
         """Test Redis health check failure"""
         mock_client = AsyncMock()
         mock_client.ping = AsyncMock(side_effect=Exception("Connection failed"))
-        
+
+        from src.main import app_state
+        app_state.health_checks.clear()
+
         with patch('src.main.get_redis_client', return_value=mock_client):
             result = await health_check_redis()
             
@@ -236,20 +239,20 @@ class TestApplicationLifecycle:
     async def test_lifespan_startup(self):
         """Test application startup lifecycle"""
         from src.main import app_state
-        
+
         # Mock the lifespan context manager
         with patch('src.main.register_service') as mock_register:
             # Test startup would set startup_time
-            assert "startup_time" in app_state
+            assert hasattr(app_state, "startup_time")
             # In real startup, register_service would be called
     
     def test_app_state_initialization(self):
         """Test initial application state"""
         from src.main import app_state
-        
-        assert "redis_client" in app_state
-        assert "startup_time" in app_state
-        assert "health_checks" in app_state
+
+        assert hasattr(app_state, "redis_client")
+        assert hasattr(app_state, "startup_time")
+        assert hasattr(app_state, "health_checks")
 
 
 @pytest.mark.performance 


### PR DESCRIPTION
## Summary
- introduce AppState dataclass for shared state
- switch main service to AppState attributes and expose via app.state
- adjust tests for new state management

## Testing
- `pytest editorial-service/tests/unit/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4cb93e0832299c8929d236f884f