### PR TITLE
docs: fix quick start references and clean up READMEs

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,38 @@
+# Quick Start
+
+## Prerequisites
+- Docker
+- Python 3.11+
+
+## 1. Setup
+```bash
+# Clone and enter repo
+# git clone <repo-url>
+cd vectorwave.io
+```
+
+## 2. Run (Docker)
+```bash
+docker compose up --build -d
+```
+
+## 3. Run (Direct)
+```bash
+pip install -r requirements-test.txt
+python editorial-service/main.py
+```
+
+## 4. Verify
+```bash
+curl http://localhost:8040/health
+open http://localhost:8040/docs
+```
+
+## 5. Basic Flow
+- `curl -s -X POST http://localhost:8041/topics/novelty-check -H 'Content-Type: application/json' -d '{"title":"Test","summary":"Short"}'`
+
+## 6. Troubleshooting
+- `docker compose logs <service>` to inspect failing containers.
+
+## 7. Next Steps
+- See [README.md](README.md) for full architecture and service details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 Ten indeks prowadzi do kluczowych dokumentów, standardów i przewodników.
 
 ## Spis
-- Quick Start: ../QUICK_START.md
+ - [Quick Start](../QUICK_START.md)
 - Kontekst projektu: ../PROJECT_CONTEXT.md
 - Plan konsolidacji dokumentacji: ./DOCS_CONSOLIDATION_PLAN.md
 - Inwentarz dokumentów: ./DOCS_INVENTORY.md

--- a/editorial-service/README.md
+++ b/editorial-service/README.md
@@ -206,30 +206,17 @@ Ten service implementuje **container-first approach** zgodny z najlepszymi prakt
 
 ## 🚀 Quick Start
 
-### Development Environment
+### Uruchomienie
 
 ```bash
-# 1. Uruchom stack development
-docker-compose -f docker-compose.dev.yml up --build
+# 1. Zbuduj i uruchom serwis wraz z ChromaDB
+docker compose up --build editorial-service chromadb
 
 # 2. Sprawdź health endpoints
 curl http://localhost:8040/health
 curl http://localhost:8000/api/v1/heartbeat  # ChromaDB
 
-# 3. Hot-reload development
-# Pliki src/ są zamontowane jako volumes - zmiany od razu widoczne
-```
-
-### Production Environment
-
-```bash
-# 1. Build production image
-docker-compose -f docker-compose.prod.yml build
-
-# 2. Deploy with resource limits
-docker-compose -f docker-compose.prod.yml up -d
-
-# 3. Monitor resources
+# 3. Monitoruj zasoby (opcjonalnie)
 docker stats editorial-service chromadb
 ```
 


### PR DESCRIPTION
## Summary
- remove links to missing docker-compose files in Editorial Service README
- add top-level Quick Start guide and fix docs index link
- deduplicate Topic Manager README and align sections with template

## Testing
- `pre-commit run --files docs/README.md editorial-service/README.md topic-manager/README.md QUICK_START.md`
- `pytest -q` *(fails: 11 errors during collection in knowledge-base tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e3e326bc83228502030ac75b3ca3