### PR TITLE
Add missing os and pytest imports in knowledge base tests

### DIFF
--- a/knowledge-base/tests/conftest.py
+++ b/knowledge-base/tests/conftest.py
@@ -1,7 +1,8 @@
 """Pytest configuration and shared fixtures for Knowledge Base tests"""
 
-import asyncio
+import os
 import pytest
+import asyncio
 import uuid
 from typing import Dict, Any, List
 from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
## Summary
- ensure knowledge-base test helpers import `os` and `pytest`

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e5e3d36c83229b13859cfb0bc865